### PR TITLE
Do not implicitly query for _spf.DOMAIN.EXT record

### DIFF
--- a/lib/spf/query/query.rb
+++ b/lib/spf/query/query.rb
@@ -18,20 +18,17 @@ module SPF
     # @api semipublic
     #
     def self.query(domain,resolver=Resolv::DNS.new)
-      # check for SPF in the TXT records
-      ["_spf.#{domain}", domain].each do |host|
-        begin
-          records = resolver.getresources(host, Resolv::DNS::Resource::IN::TXT)
+      begin
+        records = resolver.getresources(domain, Resolv::DNS::Resource::IN::TXT)
 
-          records.each do |record|
-            txt = record.strings.join
+        records.each do |record|
+          txt = record.strings.join
 
-            if txt.include?('v=spf1')
-              return txt
-            end
+          if txt.include?('v=spf1')
+            return txt
           end
-        rescue Resolv::ResolvError
         end
+      rescue Resolv::ResolvError
       end
 
       # check for an SPF record on the domain

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -15,7 +15,7 @@ describe SPF::Query do
       let(:domain) { 'google.com' }
 
       it "should return the first SPF record" do
-        expect(subject.query(domain)).to be == %{v=spf1 include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com ~all}
+        expect(subject.query(domain)).to be == %{v=spf1 include:_spf.google.com ~all}
       end
     end
 
@@ -41,7 +41,6 @@ describe SPF::Query do
       it "should prefer the TXT type record over other SPF records" do
         expect_any_instance_of(Resolv::DNS).to_not receive(:getresource).with("getlua.com", Resolv::DNS::Resource::IN::SPF)
         expect_any_instance_of(Resolv::DNS).to receive(:getresources).with("getlua.com", Resolv::DNS::Resource::IN::TXT).at_least(:once).and_call_original
-        expect_any_instance_of(Resolv::DNS).to receive(:getresources).with("_spf.getlua.com", Resolv::DNS::Resource::IN::TXT).at_least(:once).and_call_original
 
         expect(subject.query(domain)).to be == %{v=spf1 include:_spf.google.com include:mail.zendesk.com include:servers.mcsv.net include:aspmx.pardot.com -all}
       end


### PR DESCRIPTION
Fixes https://github.com/trailofbits/spf-query/issues/10

We want to make sure to always be looking at the root domain, instead of `_spf.#{domain}`.