### PR TITLE
fix - update spf parser to allow v macro_string

### DIFF
--- a/lib/spf/query/parser.rb
+++ b/lib/spf/query/parser.rb
@@ -151,7 +151,7 @@ module SPF
         ).as(:macro)
       end
       rule(:macro_literal) { match['\x21-\x24'] | match['\x26-\x7e'] }
-      rule(:macro_letter) { match['slodiphcrt'] }
+      rule(:macro_letter) { match['slodiphcrtv'] }
       rule(:transformers) do
         digit.repeat(1).as(:digits).maybe >> str('r').as(:reverse).maybe
       end


### PR DESCRIPTION
We're failing to parse the following SPF Record: `v=spf1 include:%{ir}.%{v}.%{d}.spf.has.pphosted.com -all`:

```
DEVELOPMENT irb(main):001> SPF::Query::Parser.parse("v=spf1 include:%{ir}.%{v}.%{d}.spf.has.pphosted.com -all")
/Users/rafael/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/parslet-1.8.2/lib/parslet/cause.rb:70:in `raise': Failed to match sequence (VERSION SP{1, } rules:TERMS SP{0, }) at line 1 char 22. (Parslet::ParseFailed)
```

This is because the parser is not expecting the `%{v}` macro, which is valid according to the documentation: https://datatracker.ietf.org/doc/html/rfc7208#section-7.4.

Added the `v` as a valid `macro_letter`.